### PR TITLE
[DEVOPS-870] Allow s3, kubernetes and malware protection configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,24 @@
 resource "aws_guardduty_detector" "guardduty" {
   enable                       = module.this.enabled
   finding_publishing_frequency = var.finding_publishing_frequency
+
+  datasources {
+    s3_logs {
+      enable = var.s3_protection_enabled
+    }
+    kubernetes {
+      audit_logs {
+        enable = var.kubernetes_protection_enabled
+      }
+    }
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          enable = var.malware_protection_enabled
+        }
+      }
+    }
+  }
 }
 
 data "aws_caller_identity" "current" {}

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ variable "kubernetes_protection_enabled" {
 
 variable "malware_protection_enabled" {
   description = <<-DOC
-  Flag to indicate whether snapshots are retained when malware is detected.
+  Configure whether scanning EBS volumes is enabled as data source for the detector for instances with findings.
   For more information, see:
   https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector
   DOC

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,33 @@ variable "encryption_enabled" {
   description = "Whether or not to use encryption for SNS Topic. If set to `true` a KMS key will be generated with a limited policy."
   default     = true
 }
+
+variable "s3_protection_enabled" {
+  description = <<-DOC
+  Flag to indicate whether S3 protection will be turned on in GuardDuty.
+  For more information, see:
+  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector
+  DOC
+  type        = bool
+  default     = true
+}
+
+variable "kubernetes_protection_enabled" {
+  description = <<-DOC
+  Flag to indicate whether Kubernetes protection will be turned on in GuardDuty.
+  For more information, see:
+  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector
+  DOC
+  type        = bool
+  default     = false
+}
+
+variable "malware_protection_enabled" {
+  description = <<-DOC
+  Flag to indicate whether snapshots are retained when malware is detected.
+  For more information, see:
+  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector
+  DOC
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "s3_protection_enabled" {
   https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector
   DOC
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "kubernetes_protection_enabled" {


### PR DESCRIPTION
Allow S3, kubernetes & malware snapshot retention paramaters configurable. These are enabled by default on new accounts so we would want to manage it.

* S3 & Malware protection are enabled by default
* Kubernetes protection is disabled by default as we don't use it at the moment and AWS enables it by default for new accounts so we would want to disable it.
